### PR TITLE
Update Faraday Version to 0.9.0

### DIFF
--- a/EyeEmConnector.gemspec
+++ b/EyeEmConnector.gemspec
@@ -52,7 +52,7 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<oauth2>, [">= 0"])
       s.add_runtime_dependency(%q<multi_json>, [">= 0"])
-      s.add_runtime_dependency(%q<faraday>, ["~> 0.8.0"])
+      s.add_runtime_dependency(%q<faraday>, ["~> 0.9"])
       s.add_runtime_dependency(%q<faraday_middleware>, [">= 0"])
       s.add_runtime_dependency(%q<rash>, [">= 0"])
       s.add_development_dependency(%q<rspec>, ["~> 2.8.0"])
@@ -62,7 +62,7 @@ Gem::Specification.new do |s|
     else
       s.add_dependency(%q<oauth2>, [">= 0"])
       s.add_dependency(%q<multi_json>, [">= 0"])
-      s.add_dependency(%q<faraday>, ["~> 0.8.0"])
+      s.add_dependency(%q<faraday>, ["~> 0.9"])
       s.add_dependency(%q<faraday_middleware>, [">= 0"])
       s.add_dependency(%q<rash>, [">= 0"])
       s.add_dependency(%q<rspec>, ["~> 2.8.0"])
@@ -73,7 +73,7 @@ Gem::Specification.new do |s|
   else
     s.add_dependency(%q<oauth2>, [">= 0"])
     s.add_dependency(%q<multi_json>, [">= 0"])
-    s.add_dependency(%q<faraday>, ["~> 0.8.0"])
+    s.add_dependency(%q<faraday>, ["~> 0.9"])
     s.add_dependency(%q<faraday_middleware>, [">= 0"])
     s.add_dependency(%q<rash>, [">= 0"])
     s.add_dependency(%q<rspec>, ["~> 2.8.0"])

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "http://rubygems.org"
 #   gem "activesupport", ">= 2.3.5"
   gem 'oauth2'
   gem 'multi_json'
-  gem 'faraday', "~> 0.8.0"
+  gem 'faraday', "~> 0.9"
   gem 'faraday_middleware'
   gem 'rash'
 


### PR DESCRIPTION
I don't think you meant to lock it to 0.8.0.

0.9.x _should_ be compatible here.

I would love to write some basic specs, but I fear there is a very high setup cost. May be able to get around to it later.

With extremely cursory hand testing, it looks like things work as expected.
